### PR TITLE
More friendly handling of lack of namespace for Actions

### DIFF
--- a/ndg/saml/xml/etree.py
+++ b/ndg/saml/xml/etree.py
@@ -1763,18 +1763,29 @@ class ActionElementTree(Action):
             
         action = Action()
         namespace = elem.attrib.get(cls.NAMESPACE_ATTRIB_NAME)
+        elem_value = elem.text.strip()
         if namespace is None:
             log.warning('No "%s" attribute found in "%s" element assuming '
-                        '%r action namespace' %
+                        'checking for valid action namespace' %
                         (cls.NAMESPACE_ATTRIB_NAME,
-                         cls.DEFAULT_ELEMENT_LOCAL_NAME,
-                         action.namespace))
+                         cls.DEFAULT_ELEMENT_LOCAL_NAME))
+            # Iterate across all valid namespaces and check if elem_value works
+            for namespace in cls.ACTION_NS_IDENTIFIERS:
+                try:
+                    action.namespace = namespace
+                    action.value = elem_value
+                    return action
+                except:
+                    pass
+            log.warning("No valid namespace found for action value '%s'" % (elem_value))
+            # Should cause an exception here
+            action.namespace = cls.RWEDC_NEGATION_NS_URI
+            action.value = elem_value
+            return action
         else:
             action.namespace = namespace
-            
-        action.value = elem.text.strip() 
-        
-        return action
+            action.value = elem_value
+            return action
     
     
 class AuthzDecisionQueryElementTree(AuthzDecisionQuery):


### PR DESCRIPTION
Ran into an issue where the ESGF auth service was not specifying the namespace on actions returned from the AuthzDecisionQuery. This meant that the library would fill in with the `RWEDC_NEGATION_NS_URI`, even though my query used the `GHPP_NS_URI`, and would then barf on the assignment to action.value with a value of "GET".

To address this, I made it iterate across all available action namespace URIs, in an attempt to find one that works with the action.value (but only if the namespace isn't specified).
